### PR TITLE
[bug] Without `FEATURES=page-alloc-64g` unable to run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ FEATURES ?=
 APP_FEATURES ?=
 # make `FEATURES=page-alloc-64g` as the default configuration
 MEM_FEATURES ?= page-alloc-64g
-FEATURES += MEM_FEATURES
+FEATURES += $(MEM_FEATURES)
 
 # QEMU options
 BLK ?= y

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,16 @@ A ?= $(CURDIR)
 APP ?= $(A)
 FEATURES ?=
 APP_FEATURES ?=
+# make `FEATURES=page-alloc-64g` as the default configuration
+MEM_FEATURES ?= page-alloc-64g
+FEATURES += MEM_FEATURES
 
 # QEMU options
 BLK ?= y
 NET ?= n
 GRAPHIC ?= n
 # To keep consistent with the latest `main` branch of ArceOS.
-MEM ?= 128M
+MEM ?= 4G
 BUS ?= pci
 
 DISK_IMG ?= disk.img


### PR DESCRIPTION
``` bash
[  0.007195 0 axruntime::lang_items:5] panicked at /bitmap-allocator-0.2.0/src/lib.rs:200:9:
assertion failed: end <= Self::CAP
```
The default page allocator cannot support this size without `FEATURES=page-alloc-64g` enabled.