### PR TITLE
Pin version with tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,9 +698,9 @@ dependencies = [
 [[package]]
 name = "axplat"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?branch=vmm#c38bbc1d58733ca0c90256000f9a900917f255c8"
+source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.2.0#c38bbc1d58733ca0c90256000f9a900917f255c8"
 dependencies = [
- "axplat-macros 0.1.0 (git+https://github.com/arceos-hypervisor/axplat_crates.git?branch=vmm)",
+ "axplat-macros 0.1.0 (git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.2.0)",
  "bitflags 2.10.0",
  "const-str",
  "crate_interface",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "axplat-macros"
 version = "0.1.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?branch=vmm#c38bbc1d58733ca0c90256000f9a900917f255c8"
+source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.2.0#c38bbc1d58733ca0c90256000f9a900917f255c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -877,11 +877,11 @@ dependencies = [
 [[package]]
 name = "axplat-x86-pc"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?branch=vmm#c38bbc1d58733ca0c90256000f9a900917f255c8"
+source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.2.0#c38bbc1d58733ca0c90256000f9a900917f255c8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
- "axplat 0.2.0 (git+https://github.com/arceos-hypervisor/axplat_crates.git?branch=vmm)",
+ "axplat 0.2.0 (git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.2.0)",
  "bitflags 2.10.0",
  "heapless 0.9.1",
  "int_ratio",
@@ -901,7 +901,7 @@ dependencies = [
 name = "axplat-x86-qemu-q35"
 version = "0.1.0"
 dependencies = [
- "axplat-x86-pc 0.2.0 (git+https://github.com/arceos-hypervisor/axplat_crates.git?branch=vmm)",
+ "axplat-x86-pc 0.2.0 (git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.2.0)",
 ]
 
 [[package]]

--- a/platform/x86-qemu-q35/Cargo.toml
+++ b/platform/x86-qemu-q35/Cargo.toml
@@ -8,4 +8,4 @@ fp-simd = ["axplat-x86-pc/fp-simd"]
 rtc = ["axplat-x86-pc/x86_rtc"]
 
 [dependencies]
-axplat-x86-pc = {git = "https://github.com/arceos-hypervisor/axplat_crates.git", branch="vmm", features = ["irq", "smp"]}
+axplat-x86-pc = {git = "https://github.com/arceos-hypervisor/axplat_crates.git", tag = "vmm-v0.2.0", features = ["irq", "smp"]}


### PR DESCRIPTION
Dependency management:

* Updated the `axplat-x86-pc` dependency to use the `vmm-v0.2.0` tag instead of the `vmm` branch, improving build stability and reproducibility.