### PR TITLE
refactor: migrate arceos to `dev-251202`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,10 @@ dependencies = [
 
 [[package]]
 name = "allocator"
-version = "0.1.1"
-source = "git+https://github.com/arceos-org/allocator.git?tag=v0.1.1#1d5b7a1b4fd8db4c9c9cea4e6012d15d42e2bf40"
+version = "0.1.2"
+source = "git+https://github.com/arceos-org/allocator.git?tag=v0.1.2#922e72a7e4dfb7ffc4b67d242d38f8361ebd13ac"
 dependencies = [
+ "axerrno 0.1.2",
  "bitmap-allocator",
  "cfg-if",
  "rlsf",
@@ -175,7 +176,7 @@ dependencies = [
 [[package]]
 name = "arceos_api"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -227,51 +228,18 @@ dependencies = [
 [[package]]
 name = "arm_vcpu"
 version = "0.1.1"
-dependencies = [
- "aarch64-cpu",
- "axaddrspace 0.1.3",
- "axdevice_base",
- "axerrno 0.1.2",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
- "axvisor_api",
- "log",
- "numeric-enum-macro",
- "percpu",
- "spin 0.10.0",
-]
-
-[[package]]
-name = "arm_vcpu"
-version = "0.1.1"
 source = "git+https://github.com/arceos-hypervisor/arm_vcpu?branch=next#b24cc3635c049302ab8d58d3b54007bb5a053a96"
 dependencies = [
  "aarch64-cpu",
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axdevice_base",
  "axerrno 0.1.2",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
+ "axvcpu",
  "axvisor_api",
  "log",
  "numeric-enum-macro",
  "percpu",
  "spin 0.10.0",
-]
-
-[[package]]
-name = "arm_vgic"
-version = "0.1.0"
-dependencies = [
- "aarch64-cpu",
- "aarch64_sysreg",
- "axaddrspace 0.1.3",
- "axdevice_base",
- "axerrno 0.1.2",
- "axvisor_api",
- "bitmaps",
- "log",
- "memory_addr",
- "spin 0.9.8",
- "tock-registers 0.10.1",
 ]
 
 [[package]]
@@ -282,7 +250,7 @@ checksum = "80f576b11b486e2ca12373c8205c4a06473a85cf7a664845e5961c47948910c3"
 dependencies = [
  "aarch64-cpu",
  "aarch64_sysreg",
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axdevice_base",
  "axerrno 0.1.2",
  "axvisor_api",
@@ -300,7 +268,7 @@ source = "git+https://github.com/arceos-hypervisor/arm_vgic.git#81338d6dd8a9dab0
 dependencies = [
  "aarch64-cpu",
  "aarch64_sysreg",
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axdevice_base",
  "axerrno 0.1.2",
  "axvisor_api",
@@ -322,12 +290,6 @@ name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
-
-[[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
@@ -354,28 +316,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axaddrspace"
-version = "0.1.1"
-dependencies = [
- "assert_matches",
- "axerrno 0.1.2",
- "axin",
- "bit_field",
- "bitflags 2.10.0",
- "cfg-if",
- "lazy_static",
- "lazyinit",
- "log",
- "memory_addr",
- "memory_set",
- "numeric-enum-macro",
- "page_table_entry",
- "page_table_multiarch",
- "spin 0.10.0",
- "x86",
-]
-
-[[package]]
-name = "axaddrspace"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06b129114ab36be728ef11dd6540559c30deb6332378157d22bdc0aae6803a63"
@@ -397,7 +337,7 @@ dependencies = [
 [[package]]
 name = "axalloc"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "allocator",
  "axerrno 0.1.2",
@@ -405,6 +345,18 @@ dependencies = [
  "kspin",
  "log",
  "memory_addr",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "axbacktrace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9566516f5d799b2f791a6ec5af57eec87d17624346f7c876fa006b922c99e6"
+dependencies = [
+ "cfg-if",
+ "log",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -438,11 +390,11 @@ dependencies = [
 
 [[package]]
 name = "axcpu"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e09bc1235e3da45e942b50f47812f8397ad84cb490264bf914c65ac44e6f8b1d"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/axcpu.git?tag=dev-v03#72ef3859952b7340bae261c9a50c32705e602017"
 dependencies = [
  "aarch64-cpu",
+ "axbacktrace",
  "cfg-if",
  "lazyinit",
  "linkme",
@@ -462,26 +414,10 @@ dependencies = [
 [[package]]
 name = "axdevice"
 version = "0.1.0"
-dependencies = [
- "arm_vgic 0.1.0 (git+https://github.com/arceos-hypervisor/arm_vgic.git)",
- "axaddrspace 0.1.3",
- "axdevice_base",
- "axerrno 0.1.2",
- "axvmconfig",
- "cfg-if",
- "log",
- "memory_addr",
- "range-alloc",
- "spin 0.9.8",
-]
-
-[[package]]
-name = "axdevice"
-version = "0.1.0"
 source = "git+https://github.com/arceos-hypervisor/axdevice.git#60558bb25214c2030651726beddae088d8a1cd8e"
 dependencies = [
  "arm_vgic 0.1.0 (git+https://github.com/arceos-hypervisor/arm_vgic.git)",
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axdevice_base",
  "axerrno 0.1.2",
  "axvmconfig",
@@ -498,7 +434,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c43baf33ed4790ffd3365c4ca027a1e3d1c2b6058f4605b67bca04cadf48d5"
 dependencies = [
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axerrno 0.1.2",
  "axvmconfig",
  "cfg-if",
@@ -509,10 +445,9 @@ dependencies = [
 [[package]]
 name = "axdisplay"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axdriver",
- "axdriver_display",
  "axsync",
  "lazyinit",
  "log",
@@ -521,7 +456,7 @@ dependencies = [
 [[package]]
 name = "axdriver"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "arm-gic-driver",
  "axalloc",
@@ -534,28 +469,29 @@ dependencies = [
  "axdriver_virtio",
  "axerrno 0.1.2",
  "axhal",
- "axklib 0.2.0 (git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1)",
+ "axklib",
+ "axmm",
  "cfg-if",
  "crate_interface",
  "dma-api 0.5.2",
- "lazyinit",
  "log",
  "memory_addr",
  "rdif-block",
  "rdif-intc",
  "rdrive",
+ "smallvec",
  "spin 0.10.0",
 ]
 
 [[package]]
 name = "axdriver_base"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.2#84eb2170f865e6fa29b78995a86f4fcdcede63df"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#cada10715c1f4c08b63d5d60345d2bedbc39bcd8"
 
 [[package]]
 name = "axdriver_block"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.2#84eb2170f865e6fa29b78995a86f4fcdcede63df"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#cada10715c1f4c08b63d5d60345d2bedbc39bcd8"
 dependencies = [
  "axdriver_base",
  "log",
@@ -564,7 +500,7 @@ dependencies = [
 [[package]]
 name = "axdriver_display"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.2#84eb2170f865e6fa29b78995a86f4fcdcede63df"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#cada10715c1f4c08b63d5d60345d2bedbc39bcd8"
 dependencies = [
  "axdriver_base",
 ]
@@ -572,7 +508,7 @@ dependencies = [
 [[package]]
 name = "axdriver_net"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.2#84eb2170f865e6fa29b78995a86f4fcdcede63df"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#cada10715c1f4c08b63d5d60345d2bedbc39bcd8"
 dependencies = [
  "axdriver_base",
  "log",
@@ -582,7 +518,7 @@ dependencies = [
 [[package]]
 name = "axdriver_pci"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.2#84eb2170f865e6fa29b78995a86f4fcdcede63df"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#cada10715c1f4c08b63d5d60345d2bedbc39bcd8"
 dependencies = [
  "virtio-drivers",
 ]
@@ -590,10 +526,11 @@ dependencies = [
 [[package]]
 name = "axdriver_virtio"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.2#84eb2170f865e6fa29b78995a86f4fcdcede63df"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#cada10715c1f4c08b63d5d60345d2bedbc39bcd8"
 dependencies = [
  "axdriver_base",
  "axdriver_block",
+ "log",
  "virtio-drivers",
 ]
 
@@ -620,13 +557,13 @@ dependencies = [
 [[package]]
 name = "axfeat"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axalloc",
+ "axbacktrace",
  "axdriver",
  "axfs",
  "axhal",
- "axklib-impl",
  "axlog",
  "axruntime",
  "axsync",
@@ -637,7 +574,7 @@ dependencies = [
 [[package]]
 name = "axfs"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axdriver",
  "axdriver_block",
@@ -646,13 +583,13 @@ dependencies = [
  "axfs_ramfs",
  "axfs_vfs",
  "axio",
- "axns",
  "axsync",
  "cap_access",
  "cfg-if",
  "fatfs",
  "lazyinit",
  "log",
+ "scope-local",
 ]
 
 [[package]]
@@ -691,20 +628,18 @@ dependencies = [
 [[package]]
 name = "axhal"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
- "aarch64-cpu",
  "axalloc",
  "axconfig",
  "axcpu",
- "axlog",
  "axplat",
  "axplat-aarch64-qemu-virt",
  "axplat-loongarch64-qemu-virt",
  "axplat-riscv64-qemu-virt",
  "axplat-x86-pc",
  "cfg-if",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "kernel_guard",
  "lazyinit",
  "linkme",
@@ -717,30 +652,10 @@ dependencies = [
 [[package]]
 name = "axhvc"
 version = "0.1.0"
-dependencies = [
- "axerrno 0.1.2",
- "numeric-enum-macro",
-]
-
-[[package]]
-name = "axhvc"
-version = "0.1.0"
 source = "git+https://github.com/arceos-hypervisor/axhvc.git#8b07150208803180bffc6187e6373b7ead013054"
 dependencies = [
  "axerrno 0.2.2",
  "numeric-enum-macro",
-]
-
-[[package]]
-name = "axin"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db62cb7067e33d432df247b32ee450ae267cb16319c8c5de247381c3652a639"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]
@@ -755,7 +670,7 @@ dependencies = [
 [[package]]
 name = "axipi"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axconfig",
  "axhal",
@@ -768,38 +683,17 @@ dependencies = [
 [[package]]
 name = "axklib"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-hypervisor/axklib.git#7c0fc0588f978f7d75bb94f4e07477776ed37887"
 dependencies = [
  "axerrno 0.1.2",
  "memory_addr",
- "trait-ffi",
-]
-
-[[package]]
-name = "axklib"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axklib#7c0fc0588f978f7d75bb94f4e07477776ed37887"
-dependencies = [
- "axerrno 0.1.2",
- "memory_addr",
- "trait-ffi",
-]
-
-[[package]]
-name = "axklib-impl"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
-dependencies = [
- "axhal",
- "axklib 0.2.0 (git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1)",
- "axmm",
  "trait-ffi",
 ]
 
 [[package]]
 name = "axlog"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "cfg-if",
  "crate_interface",
@@ -810,9 +704,10 @@ dependencies = [
 [[package]]
 name = "axmm"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axalloc",
+ "axconfig",
  "axerrno 0.1.2",
  "axhal",
  "kspin",
@@ -825,10 +720,9 @@ dependencies = [
 [[package]]
 name = "axnet"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axdriver",
- "axdriver_net",
  "axerrno 0.1.2",
  "axhal",
  "axio",
@@ -842,18 +736,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "axns"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
-dependencies = [
- "crate_interface",
- "lazyinit",
-]
-
-[[package]]
 name = "axplat"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.3.0#3345f58f3da5ef2eafcfa1fcf1ac32e5e80e1a7d"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axplat-macros",
  "bitflags 2.10.0",
@@ -862,12 +747,13 @@ dependencies = [
  "handler_table",
  "kspin",
  "memory_addr",
+ "percpu",
 ]
 
 [[package]]
 name = "axplat-aarch64-dyn"
 version = "0.3.0"
-source = "git+https://github.com/arceos-hypervisor/axplat-aarch64-dyn?tag=v0.3.3#de5acd47da8540f46c81e1eef69af65965404dbd"
+source = "git+https://github.com/arceos-hypervisor/axplat-aarch64-dyn.git?branch=v03#a56ba9f65dededb6fc8ec0d6306dcab3d0536865"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -894,8 +780,8 @@ dependencies = [
 
 [[package]]
 name = "axplat-aarch64-peripherals"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.3.0#3345f58f3da5ef2eafcfa1fcf1ac32e5e80e1a7d"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "aarch64-cpu",
  "arm-gic-driver",
@@ -913,8 +799,8 @@ dependencies = [
 
 [[package]]
 name = "axplat-aarch64-qemu-virt"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.3.0#3345f58f3da5ef2eafcfa1fcf1ac32e5e80e1a7d"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -926,8 +812,8 @@ dependencies = [
 
 [[package]]
 name = "axplat-loongarch64-qemu-virt"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.3.0#3345f58f3da5ef2eafcfa1fcf1ac32e5e80e1a7d"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -936,14 +822,14 @@ dependencies = [
  "lazyinit",
  "log",
  "loongArch64",
- "ns16550a",
  "page_table_entry",
+ "uart_16550",
 ]
 
 [[package]]
 name = "axplat-macros"
 version = "0.1.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.3.0#3345f58f3da5ef2eafcfa1fcf1ac32e5e80e1a7d"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -952,21 +838,25 @@ dependencies = [
 
 [[package]]
 name = "axplat-riscv64-qemu-virt"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.3.0#3345f58f3da5ef2eafcfa1fcf1ac32e5e80e1a7d"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
  "axplat",
+ "kspin",
+ "lazyinit",
  "log",
  "riscv",
+ "riscv_plic",
  "sbi-rt",
+ "uart_16550",
 ]
 
 [[package]]
 name = "axplat-x86-pc"
-version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/axplat_crates.git?tag=vmm-v0.3.0#3345f58f3da5ef2eafcfa1fcf1ac32e5e80e1a7d"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -1010,6 +900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "axpoll"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06a0cf7cffe0e87c338f41d59bd0a05fa75cf9c4799b4107fa0fc6cf27d8d23"
+dependencies = [
+ "bitflags 2.10.0",
+ "linux-raw-sys 0.11.0",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "axruntime"
 version = "0.1.0"
 dependencies = [
@@ -1049,7 +950,7 @@ dependencies = [
 [[package]]
 name = "axstd"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "arceos_api",
  "axerrno 0.1.2",
@@ -1062,9 +963,10 @@ dependencies = [
 [[package]]
 name = "axsync"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axtask",
+ "event-listener",
  "kspin",
  "lock_api",
 ]
@@ -1072,21 +974,25 @@ dependencies = [
 [[package]]
 name = "axtask"
 version = "0.2.0"
-source = "git+https://github.com/arceos-hypervisor/arceos.git?tag=hv-0.4.1#781fd8e99456c531568ccdc906312e7ef98d2fbf"
+source = "git+https://github.com/arceos-org/arceos.git?tag=dev-251202#fe9bf0f2ac3825ecc580b7ef149ff093cfc6aaca"
 dependencies = [
  "axconfig",
+ "axerrno 0.1.2",
  "axhal",
+ "axpoll",
  "axsched",
  "cfg-if",
  "cpumask",
  "crate_interface",
+ "event-listener",
+ "extern-trait",
+ "futures-util",
  "kernel_guard",
  "kspin",
  "lazyinit",
  "log",
  "memory_addr",
  "percpu",
- "timer_list",
 ]
 
 [[package]]
@@ -1144,20 +1050,9 @@ dependencies = [
 [[package]]
 name = "axvcpu"
 version = "0.1.2"
-dependencies = [
- "axaddrspace 0.1.3",
- "axerrno 0.1.2",
- "axvisor_api",
- "memory_addr",
- "percpu",
-]
-
-[[package]]
-name = "axvcpu"
-version = "0.1.2"
 source = "git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next#343ec3ccf99a86fb9c67a7b0372e9b7a745f0640"
 dependencies = [
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axerrno 0.1.2",
  "axvisor_api",
  "memory_addr",
@@ -1171,23 +1066,24 @@ dependencies = [
  "aarch64-cpu-ext",
  "anyhow",
  "arm-gic-driver",
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axconfig",
- "axdevice 0.1.0 (git+https://github.com/arceos-hypervisor/axdevice.git)",
+ "axdevice",
  "axdevice_base",
- "axerrno 0.1.2",
- "axhvc 0.1.0 (git+https://github.com/arceos-hypervisor/axhvc.git)",
+ "axerrno 0.2.2",
+ "axhvc",
  "axruntime",
  "axstd",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
+ "axvcpu",
  "axvisor_api",
- "axvm 0.1.0 (git+https://github.com/arceos-hypervisor/axvm.git?branch=next)",
+ "axvm",
  "bitflags 2.10.0",
  "byte-unit",
  "cfg-if",
  "cpumask",
  "crate_interface",
  "driver",
+ "extern-trait",
  "fdt-parser",
  "kernel_guard",
  "kspin",
@@ -1215,7 +1111,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa7233b2a1338dc06a80e2779b572b4df02007ea128ef7b235b66fc3eeac0ca6"
 dependencies = [
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axvisor_api_proc",
  "crate_interface",
  "memory_addr",
@@ -1236,14 +1132,15 @@ dependencies = [
 [[package]]
 name = "axvm"
 version = "0.1.0"
+source = "git+https://github.com/arceos-hypervisor/axvm.git?branch=next#e161233e58c0ef0c6ec115ffa5b0d17dadd298be"
 dependencies = [
- "arm_vcpu 0.1.1 (git+https://github.com/arceos-hypervisor/arm_vcpu?branch=next)",
+ "arm_vcpu",
  "arm_vgic 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "axaddrspace 0.1.3",
- "axdevice 0.1.0 (git+https://github.com/arceos-hypervisor/axdevice.git)",
+ "axaddrspace",
+ "axdevice",
  "axdevice_base",
- "axerrno 0.1.2",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
+ "axerrno 0.2.2",
+ "axvcpu",
  "axvmconfig",
  "cfg-if",
  "cpumask",
@@ -1254,32 +1151,7 @@ dependencies = [
  "percpu",
  "riscv_vcpu",
  "spin 0.9.8",
- "x86_vcpu 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "axvm"
-version = "0.1.0"
-source = "git+https://github.com/arceos-hypervisor/axvm.git?branch=next#0393f27dea948433e53285a400e356cdfd4c4fa3"
-dependencies = [
- "arm_vcpu 0.1.1 (git+https://github.com/arceos-hypervisor/arm_vcpu?branch=next)",
- "arm_vgic 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "axaddrspace 0.1.3",
- "axdevice 0.1.0 (git+https://github.com/arceos-hypervisor/axdevice.git)",
- "axdevice_base",
- "axerrno 0.1.2",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
- "axvmconfig",
- "cfg-if",
- "cpumask",
- "log",
- "memory_addr",
- "page_table_entry",
- "page_table_multiarch",
- "percpu",
- "riscv_vcpu",
- "spin 0.9.8",
- "x86_vcpu 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_vcpu",
 ]
 
 [[package]]
@@ -1701,6 +1573,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2183,7 +2064,7 @@ dependencies = [
 name = "driver"
 version = "0.1.0"
 dependencies = [
- "axklib 0.2.0 (git+https://github.com/arceos-hypervisor/axklib)",
+ "axklib",
  "log",
  "phytium-mci",
  "rdif-block",
@@ -2372,6 +2253,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "extern-trait"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8f5038f5845165d06fe1453fe4130ad546d3314818bbda57e208e7b0cffe08"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3513,6 +3415,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50a49ecd4114cf87f7e442ec5dd03bd590e7094541f987057310dbb32a6341ad"
 dependencies = [
+ "axerrno 0.1.2",
  "memory_addr",
 ]
 
@@ -3612,12 +3515,6 @@ dependencies = [
 [[package]]
 name = "nop"
 version = "0.1.0"
-
-[[package]]
-name = "ns16550a"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cd8abe9e54bce27659507b94f355c9334378ab15da332b6986b3583ebf7228"
 
 [[package]]
 name = "num"
@@ -3850,7 +3747,6 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa11a21844255e14aa6688ef0eafb058d7be19338633024fb59417f1bfb07f8"
 dependencies = [
- "bitmaps",
  "log",
  "memory_addr",
  "page_table_entry",
@@ -4637,14 +4533,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
+name = "riscv_plic"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e701d1c6ea06c35a19cb80d213fab87d264798f9bac0aed2730c0e86d297394a"
+dependencies = [
+ "tock-registers 0.10.1",
+]
+
+[[package]]
 name = "riscv_vcpu"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13f38f28fe6c02bb3ced43087c9667b23d18adf729becdc5adf1253f7df83904"
 dependencies = [
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axerrno 0.1.2",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
+ "axvcpu",
  "axvisor_api",
  "bit_field",
  "bitflags 2.10.0",
@@ -4929,6 +4834,16 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "scope-local"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e441739fbe668e91acf8440a0b1ac83c73faec7a6d984190ee25354c2ec9a"
+dependencies = [
+ "percpu",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -6649,38 +6564,13 @@ dependencies = [
 [[package]]
 name = "x86_vcpu"
 version = "0.1.0"
-dependencies = [
- "axaddrspace 0.1.3",
- "axdevice_base",
- "axerrno 0.1.2",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
- "axvisor_api",
- "bit_field",
- "bitflags 2.10.0",
- "cfg-if",
- "crate_interface",
- "log",
- "memory_addr",
- "numeric-enum-macro",
- "page_table_entry",
- "paste",
- "raw-cpuid 11.6.0",
- "spin 0.9.8",
- "x86",
- "x86_64",
- "x86_vlapic",
-]
-
-[[package]]
-name = "x86_vcpu"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "873e097d52e94c31be3f0175a9f8d6f2edbc77d7e2f8e6995427df9c08b30a2b"
 dependencies = [
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axdevice_base",
  "axerrno 0.1.2",
- "axvcpu 0.1.2 (git+https://github.com/arceos-hypervisor/axvcpu.git?branch=next)",
+ "axvcpu",
  "axvisor_api",
  "bit_field",
  "bitflags 2.10.0",
@@ -6704,7 +6594,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2556c62649a277ccf1c3c34c740be87bbde5f8dab0b20fcdcf4c2cd7bb6e7302"
 dependencies = [
- "axaddrspace 0.1.3",
+ "axaddrspace",
  "axdevice_base",
  "axerrno 0.1.2",
  "axvisor_api",
@@ -6741,6 +6631,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "flate2",
  "jkconfig",
  "ostool",
  "reqwest 0.12.24",
@@ -6748,6 +6639,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tokio",
  "toml 0.9.8",
  "zerocopy 0.8.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,37 +32,41 @@ timer_list = "0.1"
 toml = "0.9"
 
 # System dependent modules provided by ArceOS.
-axstd = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1", features = [
+# FIXME: pin to a specific tag!
+axstd = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202", features = [
   "alloc-level-1",
   "paging",
   "irq",
   "multitask",
+  "task-ext",
   "smp", # "page-alloc-64g",
 ]}
 
-axalloc = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axconfig = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axdisplay = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axdriver = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axfs = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axhal = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axipi = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axlog = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axmm = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axnet = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
-axtask = {git = "https://github.com/arceos-hypervisor/arceos.git", tag = "hv-0.4.1"}
+axalloc = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axconfig = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axdisplay = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axdriver = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axfs = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axhal = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axipi = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axlog = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axmm = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axnet = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
+axtask = {git = "https://github.com/arceos-org/arceos.git", tag = "dev-251202"}
 
-axplat = {git = "https://github.com/arceos-hypervisor/axplat_crates.git", tag = "vmm-v0.3.0"}
+axcpu = {git = "https://github.com/arceos-org/axcpu.git", tag = "dev-v03"}
+axplat = {git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03"}
 
 # System dependent modules provided by ArceOS-Hypervisor.
 axaddrspace = "0.1.1"
 axhvc = {git = "https://github.com/arceos-hypervisor/axhvc.git"}
+axklib = {git = "https://github.com/arceos-hypervisor/axklib.git"}
 axruntime = {path = "modules/axruntime"}
 axvcpu = "0.1"
 axvm = {git = "https://github.com/arceos-hypervisor/axvm.git", branch = "next"}
 
 # System independent crates provided by ArceOS, these crates could be imported by remote url. 
-axerrno = "0.1.0"
+axerrno = "0.2"
 byte-unit = {version = "5", default-features = false, features = ["byte"]}
 crate_interface = "0.1"
 fdt-parser = "0.4"
@@ -88,6 +92,6 @@ axvmconfig = {git = "https://github.com/arceos-hypervisor/axvmconfig.git", branc
 axvcpu = {git = "https://github.com/arceos-hypervisor/axvcpu.git", branch = "next"}
 axvmconfig = {git = "https://github.com/arceos-hypervisor/axvmconfig.git", branch = "next"}
 
-[patch."https://github.com/arceos-hypervisor/arceos"]
+[patch."https://github.com/arceos-org/arceos"]
 axconfig = {path = "modules/axconfig"}
 axruntime = {path = "modules/axruntime"}

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -41,6 +41,7 @@ axvm.workspace = true
 axerrno.workspace = true
 byte-unit = {version = "5", default-features = false, features = ["byte"]}
 crate_interface.workspace = true
+extern-trait = "0.2"
 fdt-parser = "0.4"
 memory_addr.workspace = true
 page_table_entry = {version = "0.5", features = ["arm-el2"]}
@@ -62,7 +63,7 @@ aarch64-cpu-ext = "0.1"
 arm-gic-driver = {version = "0.15.5", features = ["rdif"]}
 
 [build-dependencies]
-axconfig = {git = "https://github.com/arceos-hypervisor/arceos.git", branch = "vmm-dev"}
+axconfig.workspace = true
 prettyplease = "0.2"
 quote = "1.0"
 syn = "2.0"

--- a/kernel/src/vmm/mod.rs
+++ b/kernel/src/vmm/mod.rs
@@ -13,12 +13,15 @@ pub mod fdt;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::os::arceos::{
     api::task::{self, AxWaitQueueHandle},
-    modules::axtask::{self, TaskExtRef},
+    modules::axtask,
 };
 
 use axerrno::{AxResult, ax_err_type};
 
-use crate::hal::{AxVCpuHalImpl, AxVMHalImpl};
+use crate::{
+    hal::{AxVCpuHalImpl, AxVMHalImpl},
+    task::AsVCpuTask,
+};
 pub use timer::init_percpu as init_timer_percpu;
 
 /// The instantiated VM type.
@@ -107,8 +110,8 @@ pub fn with_vm_and_vcpu_on_pcpu(
     // Disables preemption and IRQs to prevent the current task from being preempted or re-scheduled.
     let guard = kernel_guard::NoPreemptIrqSave::new();
 
-    let current_vm = axtask::current().task_ext().vm().id();
-    let current_vcpu = axtask::current().task_ext().vcpu.id();
+    let current_vm = axtask::current().as_vcpu_task().vm().id();
+    let current_vcpu = axtask::current().as_vcpu_task().vcpu.id();
 
     // The target vCPU is the current task, execute the closure directly.
     if current_vm == vm_id && current_vcpu == vcpu_id {

--- a/modules/axruntime/Cargo.toml
+++ b/modules/axruntime/Cargo.toml
@@ -53,5 +53,5 @@ chrono = {version = "0.4.38", default-features = false}
 axplat-x86-qemu-q35 = {workspace = true}
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-axplat-aarch64-dyn = {git = "https://github.com/arceos-hypervisor/axplat-aarch64-dyn", tag = "v0.3.3", features = ["irq", "smp", "hv"]}
+axplat-aarch64-dyn = {git = "https://github.com/arceos-hypervisor/axplat-aarch64-dyn.git", branch = "v03", features = ["irq", "smp", "hv"]}
 somehal = "0.4"

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -112,7 +112,7 @@ fn is_init_ok() -> bool {
 #[cfg_attr(not(test), axplat::main)]
 pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
     unsafe { axhal::mem::clear_bss() };
-    axhal::init_percpu(cpu_id);
+    axhal::percpu::init_primary(cpu_id);
     axhal::init_early(cpu_id, arg);
 
     ax_println!("{}", LOGO);

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -39,7 +39,7 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
 /// It is called from the bootstrapping code in the specific platform crate.
 #[axplat::secondary_main]
 pub fn rust_main_secondary(cpu_id: usize) -> ! {
-    axhal::init_percpu_secondary(cpu_id);
+    axhal::percpu::init_secondary(cpu_id);
     axhal::init_early_secondary(cpu_id);
 
     ENTERED_CPUS.fetch_add(1, Ordering::Release);

--- a/modules/driver/Cargo.toml
+++ b/modules/driver/Cargo.toml
@@ -14,7 +14,7 @@ rockchip-pm = ["dep:rockchip-pm"]
 phytium-blk = ["dep:phytium-mci"]
 
 [dependencies]
-axklib = {git = "https://github.com/arceos-hypervisor/axklib"}
+axklib.workspace = true
 log.workspace = true
 rdif-block = "0.6.2"
 rdif-clk = "0.4"

--- a/platform/x86-qemu-q35/Cargo.toml
+++ b/platform/x86-qemu-q35/Cargo.toml
@@ -17,7 +17,7 @@ smp = ["axplat/smp", "kspin/smp"]
 
 [dependencies]
 axconfig-macros = "0.2"
-axcpu = "0.2"
+axcpu = {workspace = true}
 axplat = {workspace = true}
 bitflags = "2.6"
 heapless = "0.9"

--- a/platform/x86-qemu-q35/linker.lds.S
+++ b/platform/x86-qemu-q35/linker.lds.S
@@ -94,6 +94,6 @@ SECTIONS {
     linkm2_PAGE_FAULT : { *(linkm2_PAGE_FAULT) }
     linkme_SYSCALL : { *(linkme_SYSCALL) }
     linkm2_SYSCALL : { *(linkm2_SYSCALL) }
-    axns_resource : { *(axns_resource) }
+    scope_local : { *(scope_local) }
 }
 INSERT AFTER .tbss;

--- a/platform/x86-qemu-q35/src/apic.rs
+++ b/platform/x86-qemu-q35/src/apic.rs
@@ -147,12 +147,13 @@ mod irq_impl {
         /// It is called by the common interrupt handler. It should look up in the
         /// IRQ handler table and calls the corresponding handler. If necessary, it
         /// also acknowledges the interrupt controller after handling.
-        fn handle(vector: usize) {
+        fn handle(vector: usize) -> Option<usize> {
             trace!("IRQ {}", vector);
             if !IRQ_HANDLER_TABLE.handle(vector) {
                 warn!("Unhandled IRQ {vector}");
             }
             unsafe { super::local_apic().end_of_interrupt() };
+            Some(vector)
         }
 
         /// Sends an inter-processor interrupt (IPI) to the specified target CPU or all CPUs.

--- a/platform/x86-qemu-q35/src/console.rs
+++ b/platform/x86-qemu-q35/src/console.rs
@@ -46,4 +46,12 @@ impl ConsoleIf for ConsoleIfImpl {
         }
         read_len
     }
+
+    /// Returns the IRQ number for the console input interrupt.
+    ///
+    /// Returns `None` if input interrupt is not supported.
+    #[cfg(feature = "irq")]
+    fn irq_num() -> Option<usize> {
+        None
+    }
 }

--- a/platform/x86-qemu-q35/src/time.rs
+++ b/platform/x86-qemu-q35/src/time.rs
@@ -77,11 +77,6 @@ struct TimeIfImpl;
 
 #[impl_plat_interface]
 impl TimeIf for TimeIfImpl {
-    /// Returns the IRQ number for the timer interrupt.
-    fn irq_num() -> usize {
-        0xf0
-    }
-
     /// Returns the current clock time in hardware ticks.
     fn current_ticks() -> u64 {
         unsafe { core::arch::x86_64::_rdtsc() - INIT_TICK }
@@ -101,6 +96,12 @@ impl TimeIf for TimeIfImpl {
     /// clock start).
     fn epochoffset_nanos() -> u64 {
         unsafe { RTC_EPOCHOFFSET_NANOS }
+    }
+
+    /// Returns the IRQ number for the timer interrupt.
+    #[cfg(feature = "irq")]
+    fn irq_num() -> usize {
+        0xf0
     }
 
     /// Set a one-shot timer.

--- a/scripts/lds/linker.lds.S
+++ b/scripts/lds/linker.lds.S
@@ -95,6 +95,6 @@ SECTIONS {
     linkm2_PAGE_FAULT : { *(linkm2_PAGE_FAULT) }
     linkme_SYSCALL : { *(linkme_SYSCALL) }
     linkm2_SYSCALL : { *(linkm2_SYSCALL) }
-    axns_resource : { *(axns_resource) }
+    scope_local : { *(scope_local) }
 }
 INSERT AFTER .tbss;


### PR DESCRIPTION
## TODO

- https://github.com/arceos-hypervisor/axklib/pull/1
- pin arceos to tag (dev-0.3.0 maybe)
- https://github.com/arceos-hypervisor/axhvc/pull/3
- https://github.com/arceos-hypervisor/axvm/pull/33
- https://github.com/arceos-hypervisor/axplat-aarch64-dyn/pull/2
- https://github.com/arceos-org/arceos/pull/302