### PR TITLE
fix:Fixes the "Block is free" issue when using the rsext4 file system.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "rsext4"
 version = "0.1.0"
-source = "git+https://github.com/Dirinkbottle/rsext4.git?branch=main#0198aa5142eeceaeac7182792ccc75930d951516
+source = "git+https://github.com/Dirinkbottle/rsext4.git?branch=main#0198aa5142eeceaeac7182792ccc75930d951516"
 dependencies = [
  "bitflags 2.10.0",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "rsext4"
 version = "0.1.0"
-source = "git+https://github.com/Dirinkbottle/rsext4.git?tag=dev-251222#376e253cc6b8767bc14ca5054fbc1ae49f7a8c8d"
+source = "git+https://github.com/Dirinkbottle/rsext4.git?branch=main#51110c1413aaa2ac183e2af80ce07cdee560545d"
 dependencies = [
  "bitflags 2.10.0",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "rsext4"
 version = "0.1.0"
-source = "git+https://github.com/Dirinkbottle/rsext4.git?branch=main#51110c1413aaa2ac183e2af80ce07cdee560545d"
+source = "git+https://github.com/Dirinkbottle/rsext4.git?branch=main#0198aa5142eeceaeac7182792ccc75930d951516"
 dependencies = [
  "bitflags 2.10.0",
  "lazy_static",

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -19,7 +19,7 @@ cap_access = "0.1"
 lazyinit = "0.2"
 spin = "0.9"
 log = "0.4"
-rsext4 = {git = "https://github.com/Dirinkbottle/rsext4.git", tag = "dev-251222"}
+rsext4 = {git = "https://github.com/Dirinkbottle/rsext4.git", branch = "main"}
 
 [dependencies.fatfs]
 default-features = false

--- a/modules/axfs/src/root.rs
+++ b/modules/axfs/src/root.rs
@@ -440,6 +440,7 @@ pub fn mount_virtual_fs(mut root_dir: RootDirectory) {
         panic!("Failed to mount virtual filesystems: {:?}", e);
     }
 
+
     // Initialize global state
     let root_dir = Arc::new(root_dir);
     ROOT_DIR.init_once(root_dir.clone());


### PR DESCRIPTION
## Problem 
After a client machine performs a file write operation and restarts, a "block is free" error occurs. 
## Analysis: 
rsext4 is designed with multi-level caching to improve runtime speed. However, currently, Axvisor does not perform any data synchronization during rsext4 integration. 
This means that if the machine modifies a file and shuts down immediately, the cache remains in memory, inevitably leading to hard drive failure. 
## Solution: 
In the ```ext4fs.rs``` access layer of rsext4, call ```sync_to_disk``` function for all write operations to ensure timely synchronization, even if it results in some performance loss.